### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v1.0.0
+2024-01-22
+---
+* Replace support for delaring `Model.TYPE` manually with metadata value `@:customTypeName("MyTypeName")`
+* Add Duplicate Handling feature to overwrite, ignore or throw an error if two models of the same type and name are created
+* Add a per-model Duplicate Handling feature, using metadata variable `@:duplicateHandling("Error")`, `@:duplicateHandling("Ignore")` or `@:duplicateHandling("Overwrite")`.
+* Rename static variable `Model.TYPE` to `Model.Type`
+
 # v0.1.0
+2024-01-20
 ---
 * Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v1.0.0
 2024-01-22
 ---
-* Replace support for delaring `Model.TYPE` manually with metadata value `@:customTypeName("MyTypeName")`
+* Replace support for declaring `Model.TYPE` manually with metadata value `@:customTypeName("MyTypeName")`
 * Add Duplicate Handling feature to overwrite, ignore or throw an error if two models of the same type and name are created
 * Add a per-model Duplicate Handling feature, using metadata variable `@:duplicateHandling("Error")`, `@:duplicateHandling("Ignore")` or `@:duplicateHandling("Overwrite")`.
 * Rename static variable `Model.TYPE` to `Model.Type`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It's better to show with examples.
 ```haxe
 class Person extends olib.models.Model
 {
-    // public static final TYPE:String = "Person"; is auto-generated
+    // public static final Type:String = "Person"; is auto-generated
     // public var type:String; is auto-generated
     // public var name:String; is auto-generated
     public var age:Int;
@@ -31,7 +31,7 @@ var georges = new Person("Georges", 42, "charlie"); // optional arguments are au
 // the dog charlie does not exist yet; but a reference to it now exists
 
 Model.get("Person", "Georges") == georges;
-Model.get(Person.TYPE, "Georges") == georges;
+Model.get(Person.Type, "Georges") == georges;
 Model.get(georges.type, "Georges") == georges;
 
 // create a dog
@@ -107,7 +107,7 @@ var json = sys.io.File.getContent("path/to/file.json");
 var type = Model.peek(json);
 switch (type)
 {
-    case Person.TYPE:
+    case Person.Type:
         var person = Person.parser.fromJson(json);
     case _:
         trace("unknown type");

--- a/README.md
+++ b/README.md
@@ -65,13 +65,30 @@ All models must extend olib.models.Model. By doing this, those models gain speci
 
 Models have a `name:String` field that cannot be changed after instantiation. This is the unique key to reference them by.
 
-Models also have a `type:String` field that cannot be changed after instantiation. This is the type of the model. It takes the value of the class' name, so a class `Person` will have a type of `"Person"`. It is also stored as a static `TYPE` field. The TYPE of a model can instead be manually set by declaring a public static final TYPE field with a different value. In the following example, the TYPE of Person is "Human" instead of `"Person"`.
+Models also have a `type:String` field that cannot be changed after instantiation. This is the type of the model. It takes the value of the class' name, so a class `Person` will have a type of `"Person"`. It is also stored as a static `Type` field. The Type of a model can instead be manually set by declaring a metadata value with a different type name. In the following example, the Type of Person is "Human" instead of `"Person"`.
 ```haxe
+
+@customTypeName("Human")
 class Person extends olib.models.Model
 {
-    public static final TYPE:String = "Human";
     public var name:String;
     public var age:Int;
+}
+```
+
+By default, when you instantiate two models of the same type and name, the second one overrides the first. You can change this behavior globally:
+```haxe
+Model.duplicateHandling = DuplicateHandling.Overwrite; // will overwrite the current model
+Model.duplicateHandling = DuplicateHandling.Error; // will throw a ModelException
+Model.duplicateHandling = DuplicateHandling.Ignore;	// will ignore the new model
+```
+
+You can also overwrite the behavior per model. This is useful if you want to block a model type from being overwritten, for example:
+```haxe
+@duplicateHandling("Error")
+class ImportantGameSetings extends Model
+{
+   // you wouldn't want a mod to overwrite your Settings model, so you can disable it here
 }
 ```
 

--- a/haxelib.json
+++ b/haxelib.json
@@ -8,9 +8,9 @@
         "json"
     ],
     "description": "JSON serializable typed and named models for handling structured data and references",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "classPath": "src/",
-    "releasenote": "Initial release",
+    "releasenote": "Add behavior control based on metadata, duplicate model handling, and more.",
     "contributors": [
         "oli_chose123"
     ],

--- a/src/olib/macros/MacroUtil.hx
+++ b/src/olib/macros/MacroUtil.hx
@@ -165,6 +165,52 @@ class MacroUtil
                 throw new MacroException("Type " + type + " is not supported");
         }
     }
+
+    public static function findMetadata(type:Type, name:String):Array<MetadataEntry>
+    {
+        var meta;
+        var entries;
+        switch (type)
+        {
+            case TInst(t, params):
+                meta = t.get().meta;
+            case _:
+                throw new MacroException("Type " + type + " is not supported");
+        }
+        if (!meta.has(name))
+        {
+            return null;
+        }
+        else
+        {
+            return meta.extract(name);
+        }
+        return null;
+    }
+
+    public static function findMetadataStringValue(type:Type, name:String):String
+    {
+        var entries = findMetadata(type, name);
+        if (entries == null)
+            return null;
+        if (entries.length == 0)
+            return null;
+
+        var exprdef:ExprDef = entries[0].params[0].expr;
+        switch (exprdef)
+        {
+            case EConst(c):
+                switch (c)
+                {
+                    case CString(s):
+                        return s;
+                    case _:
+                        throw new MacroException("Metadata " + name + " is not a string");
+                }
+            case _:
+                throw new MacroException("Metadata " + name + " is not a string");
+        }
+    }
 }
 
 class MacroException extends Exception {}

--- a/src/olib/models/tests/Examples.hx
+++ b/src/olib/models/tests/Examples.hx
@@ -12,10 +12,8 @@ class SimpleExample extends Model
     public var myIntValue:Int;
 }
 
-class OverridenTypeExample extends Model
-{
-    public static final TYPE:String = "OverridenTypeExample";
-}
+@customTypeName("OverridenTypeExample")
+class OverridenTypeExample extends Model {}
 
 class ReferenceExample extends Model
 {
@@ -26,3 +24,6 @@ class ArrayReferenceExample extends Model
 {
     public var myReferences:Array<Reference<SimpleExample>> = [];
 }
+
+@duplicateHandling("Error")
+class ErrorOnDuplicateExample extends Model {}

--- a/src/olib/models/tests/Tests.hx
+++ b/src/olib/models/tests/Tests.hx
@@ -1,5 +1,7 @@
 package olib.models.tests;
 
+import olib.models.Model.ModelException;
+import olib.models.Model.DuplicateHandling;
 import olib.models.tests.Examples.ArrayReferenceExample;
 import olib.models.tests.Examples.ReferenceExample;
 import haxe.Json;
@@ -17,6 +19,11 @@ class Tests extends utest.Test
         "myIntValue": 25
     }
     ';
+
+    function setup()
+    {
+        Model.duplicateHandling = DuplicateHandling.Overwrite;
+    }
 
     function testDictAccess()
     {
@@ -118,5 +125,28 @@ class Tests extends utest.Test
         #else
         Assert.equals(SimpleExample.TYPE, Model.peek(simpleExampleJSON));
         #end
+    }
+
+    function testGlobalDuplicateHandling()
+    {
+        Model.duplicateHandling = DuplicateHandling.Overwrite;
+        var exampleA = new SimpleExample("example-a", 25, "hello world");
+
+        var exampleB = new SimpleExample("example-a", 25, "hello world2");
+        var testExample:SimpleExample = Model.get("SimpleExample", "example-a");
+        Assert.equals("hello world2", testExample.myStringValue);
+
+        Model.duplicateHandling = DuplicateHandling.Ignore;
+        var exampleD = new SimpleExample("example-a", 25, "hello world3");
+        testExample = Model.get("SimpleExample", "example-a");
+        Assert.equals("hello world2", testExample.myStringValue);
+
+        Model.duplicateHandling = DuplicateHandling.Error;
+        try
+        {
+            var exampleE = new SimpleExample("example-a", 25, "hello world4");
+            Assert.fail("Should have thrown an error");
+        }
+        catch (e:ModelException) {}
     }
 }

--- a/src/olib/models/tests/Tests.hx
+++ b/src/olib/models/tests/Tests.hx
@@ -1,5 +1,6 @@
 package olib.models.tests;
 
+import olib.models.tests.Examples.ErrorOnDuplicateExample;
 import olib.models.Model.ModelException;
 import olib.models.Model.DuplicateHandling;
 import olib.models.tests.Examples.ArrayReferenceExample;
@@ -35,7 +36,7 @@ class Tests extends utest.Test
     {
         var example = new SimpleExample("example-a", 25, "hello world");
         Assert.equals("SimpleExample", example.type);
-        Assert.equals(example.type, SimpleExample.TYPE);
+        Assert.equals(example.type, SimpleExample.Type);
     }
 
     function testTypeOverride()
@@ -121,9 +122,9 @@ class Tests extends utest.Test
     {
         #if sys
         var json = sys.io.File.getContent("examples/simple-example-a.json");
-        Assert.equals(SimpleExample.TYPE, Model.peek(json));
+        Assert.equals(SimpleExample.Type, Model.peek(json));
         #else
-        Assert.equals(SimpleExample.TYPE, Model.peek(simpleExampleJSON));
+        Assert.equals(SimpleExample.Type, Model.peek(simpleExampleJSON));
         #end
     }
 
@@ -147,6 +148,24 @@ class Tests extends utest.Test
             var exampleE = new SimpleExample("example-a", 25, "hello world4");
             Assert.fail("Should have thrown an error");
         }
+        catch (e:ModelException)
+        {
+            Assert.pass();
+        }
+    }
+
+    function testLocalDuplicateHandling()
+    {
+        Model.duplicateHandling = DuplicateHandling.Overwrite;
+        var exampleA = new ErrorOnDuplicateExample("example-a");
+        try
+        {
+            var exampleB = new ErrorOnDuplicateExample("example-a");
+            Assert.fail("Should have thrown an error");
+        }
         catch (e:ModelException) {}
+        {
+            Assert.pass();
+        }
     }
 }


### PR DESCRIPTION
* Replace support for delaring `Model.TYPE` manually with metadata value `@:customTypeName("MyTypeName")`
* Add Duplicate Handling feature to overwrite, ignore or throw an error if two models of the same type and name are created
* Add a per-model Duplicate Handling feature, using metadata variable `@:duplicateHandling("Error")`, `@:duplicateHandling("Ignore")` or `@:duplicateHandling("Overwrite")`.
* Rename static variable `Model.TYPE` to `Model.Type`